### PR TITLE
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/perfcake/src/main/java/org/perfcake/message/sender/JdbcSender.java
+++ b/perfcake/src/main/java/org/perfcake/message/sender/JdbcSender.java
@@ -121,7 +121,7 @@ public class JdbcSender extends AbstractSender {
 
             log.debug("Column count: " + columnCount);
 
-            final StringBuffer sb = new StringBuffer();
+            final StringBuilder sb = new StringBuilder();
             for (int i = 1; i <= columnCount; i++) {
                sb.append(" ");
                sb.append(rsmd.getColumnName(i));

--- a/perfcake/src/main/java/org/perfcake/message/sender/LdapSender.java
+++ b/perfcake/src/main/java/org/perfcake/message/sender/LdapSender.java
@@ -29,7 +29,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import javax.naming.Context;
@@ -146,7 +146,7 @@ public class LdapSender extends AbstractSender {
 
    @Override
    public void doInit(final Properties messageAttributes) throws PerfCakeException {
-      final Hashtable<String, Object> env = new Hashtable<String, Object>();
+      final HashMap<String, Object> env = new HashMap<String, Object>();
       env.put(Context.SECURITY_AUTHENTICATION, "simple");
       if (ldapUsername != null) {
          env.put(Context.SECURITY_PRINCIPAL, ldapUsername);

--- a/perfcake/src/main/java/org/perfcake/reporting/Measurement.java
+++ b/perfcake/src/main/java/org/perfcake/reporting/Measurement.java
@@ -160,7 +160,7 @@ public class Measurement {
 
    @Override
    public String toString() {
-      final StringBuffer sb = new StringBuffer();
+      final StringBuilder sb = new StringBuilder();
       sb.append("[");
       sb.append(Utils.timeToHMS(time));
       sb.append("][");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.