### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/perfcake-agent/src/main/java/org/perfcake/agent/PerfCakeAgent.java
+++ b/perfcake-agent/src/main/java/org/perfcake/agent/PerfCakeAgent.java
@@ -99,6 +99,9 @@ public class PerfCakeAgent {
     */
    public static final int DEFAULT_PORT = 8850;
 
+   private PerfCakeAgent() {
+   }
+
    /**
     * {@link PerfCakeAgent}'s pre-main method.
     *

--- a/perfcake/src/main/java/org/perfcake/PerfCakeConst.java
+++ b/perfcake/src/main/java/org/perfcake/PerfCakeConst.java
@@ -195,4 +195,7 @@ public final class PerfCakeConst {
     * Exit code when there are blocked threads after the scenario was executed.
     */
    public static final int ERR_BLOCKED_THREADS = 6;
+
+   private PerfCakeConst() {
+   }
 }

--- a/perfcake/src/main/java/org/perfcake/util/ObjectFactory.java
+++ b/perfcake/src/main/java/org/perfcake/util/ObjectFactory.java
@@ -59,6 +59,9 @@ public class ObjectFactory {
     */
    private static ClassLoader pluginClassLoader = null;
 
+   private ObjectFactory() {
+   }
+
    /**
     * Looks up for a set method on a bean that is able to accept Element
     *

--- a/perfcake/src/main/java/org/perfcake/util/StringUtil.java
+++ b/perfcake/src/main/java/org/perfcake/util/StringUtil.java
@@ -30,6 +30,9 @@ import java.util.stream.Collectors;
  */
 public class StringUtil {
 
+   private StringUtil() {
+   }
+
    /**
     * Does a string start with a second string ignoring case?
     *

--- a/perfcake/src/main/java/org/perfcake/util/TimerBenchmark.java
+++ b/perfcake/src/main/java/org/perfcake/util/TimerBenchmark.java
@@ -42,6 +42,9 @@ public class TimerBenchmark {
     */
    private static final int CYCLES = 10 * 1024;
 
+   private TimerBenchmark() {
+   }
+
    /**
     * Measures system timer resolution.
     **/

--- a/perfcake/src/main/java/org/perfcake/util/Utils.java
+++ b/perfcake/src/main/java/org/perfcake/util/Utils.java
@@ -77,6 +77,9 @@ public class Utils {
     */
    public static final File DEFAULT_PLUGINS_DIR = new File("lib/plugins");
 
+   private Utils() {
+   }
+
    /**
     * Replaces all ${&lt;property.name&gt;} placeholders in a string
     * by respective value of the property named &lt;property.name&gt; using {@link SystemPropertyGetter}.

--- a/perfcake/src/test/java/org/perfcake/message/sender/JmsHelper.java
+++ b/perfcake/src/test/java/org/perfcake/message/sender/JmsHelper.java
@@ -43,6 +43,9 @@ import javax.naming.NamingException;
  */
 public class JmsHelper {
 
+   private JmsHelper() {
+   }
+
    public static class Wiretap implements Runnable {
 
       private static final Logger log = LogManager.getLogger(Wiretap.class);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.