### PR TITLE
Null pointers should not be dereferenced

### DIFF
--- a/perfcake/src/main/java/org/perfcake/common/BoundPeriod.java
+++ b/perfcake/src/main/java/org/perfcake/common/BoundPeriod.java
@@ -83,6 +83,9 @@ public class BoundPeriod<T> extends Period {
    @SuppressWarnings("rawtypes")
    @Override
    public boolean equals(final Object obj) {
+      if(obj == null) {
+         return false;
+      }
       if (this == obj) {
          return true;
       }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2259 - “Null pointers should not be dereferenced”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2259
Please let me know if you have any questions.
Ayman Abdelghany.