### PR TITLE
 Resources should be closed

### DIFF
--- a/perfcake-agent/src/main/java/org/perfcake/agent/AgentThread.java
+++ b/perfcake-agent/src/main/java/org/perfcake/agent/AgentThread.java
@@ -59,7 +59,7 @@ public class AgentThread implements Runnable {
    public void run() {
       InetAddress host;
       int port = PerfCakeAgent.DEFAULT_PORT;
-      ServerSocket serverSocket;
+      ServerSocket serverSocket = null;
       Socket socket;
       InputStream is = null;
 
@@ -153,6 +153,14 @@ public class AgentThread implements Runnable {
             try {
                is.close();
             } catch (final IOException e) {
+               e.printStackTrace();
+            }
+         }
+         
+         if (serverSocket != null) {
+            try {
+               serverSocket.close();
+            } catch (IOException e) {
                e.printStackTrace();
             }
          }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2095 - “Resources should be closed”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2095
Please let me know if you have any questions.
Ayman Abdelghany.